### PR TITLE
Refactor tests to use in-memory mocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>2.19.0</version>

--- a/src/test/java/org/dasein/persist/MockPersistentCache.java
+++ b/src/test/java/org/dasein/persist/MockPersistentCache.java
@@ -1,0 +1,132 @@
+import org.dasein.persist.*;
+import org.dasein.persist.annotations.Schema;
+import org.dasein.persist.jdbc.AutomatedSql.Operator;
+import org.dasein.util.CachedItem;
+import org.dasein.util.JiteratorFilter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.util.*;
+
+public class MockPersistentCache<T extends CachedItem> extends PersistentCache<T> {
+    private final Map<Object, T> store = new HashMap<>();
+
+    public MockPersistentCache(Class<T> cls) {
+        initBase(cls, null, "test", null, new Key("keyField"));
+    }
+
+    @Override
+    public T create(Transaction xaction, Map<String, Object> state) throws PersistenceException {
+        try {
+            T item = getTarget().getDeclaredConstructor().newInstance();
+            for (Map.Entry<String, Object> entry : state.entrySet()) {
+                Field f = getField(getTarget(), entry.getKey());
+                if (f != null) {
+                    set(item, f, entry.getValue());
+                }
+            }
+            Object keyVal = getValue(item, getPrimaryKeyField());
+            store.put(keyVal, item);
+            return item;
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    private Field getField(Class<?> cls, String name) {
+        Class<?> current = cls;
+        while (!current.equals(Object.class)) {
+            try {
+                Field f = current.getDeclaredField(name);
+                f.setAccessible(true);
+                return f;
+            } catch (NoSuchFieldException ignore) {
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private boolean matches(T item, SearchTerm[] terms) throws PersistenceException {
+        if (terms == null) return true;
+        for (SearchTerm term : terms) {
+            Object val = getValue(item, term.getColumn());
+            if (term.getOperator() == Operator.LIKE) {
+                if (val == null || !val.toString().contains(String.valueOf(term.getValue()))) {
+                    return false;
+                }
+            } else {
+                if (val == null || !val.equals(term.getValue())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public @Nonnull Collection<T> find(@Nonnull SearchTerm[] terms, @Nullable JiteratorFilter<T> filter,
+                                       @Nullable Boolean orderDesc, @Nullable String... orderFields) throws PersistenceException {
+        List<T> results = new ArrayList<>();
+        for (T item : store.values()) {
+            if (matches(item, terms)) {
+                results.add(item);
+            }
+        }
+        if (orderFields != null && orderFields.length > 0) {
+            final String field = orderFields[0];
+            results.sort(Comparator.comparing(o -> (Comparable) getValue(o, field)));
+            if (Boolean.TRUE.equals(orderDesc)) Collections.reverse(results);
+        }
+        return results;
+    }
+
+    @Override
+    public T get(Object keyValue) throws PersistenceException {
+        return store.get(keyValue);
+    }
+
+    @Override
+    public T get(SearchTerm... terms) throws PersistenceException {
+        for (T item : store.values()) {
+            if (matches(item, terms)) return item;
+        }
+        return null;
+    }
+
+    @Override
+    public String getSchema() {
+        return "test";
+    }
+
+    @Override
+    public Collection<T> list() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public void remove(Transaction xaction, T item) {
+        Object keyVal = getValue(item, getPrimaryKeyField());
+        store.remove(keyVal);
+    }
+
+    @Override
+    public void remove(Transaction xaction, SearchTerm... terms) throws PersistenceException {
+        for (T item : new ArrayList<>(store.values())) {
+            if (matches(item, terms)) {
+                remove(xaction, item);
+            }
+        }
+    }
+
+    @Override
+    public void update(Transaction xaction, T item, Map<String, Object> state) throws PersistenceException {
+        for (Map.Entry<String, Object> entry : state.entrySet()) {
+            Field f = getField(getTarget(), entry.getKey());
+            if (f != null) {
+                set(item, f, entry.getValue());
+            }
+        }
+    }
+}

--- a/src/test/java/org/dasein/persist/RelationalCacheTest.java
+++ b/src/test/java/org/dasein/persist/RelationalCacheTest.java
@@ -1,283 +1,70 @@
-/**
- * Copyright (C) 1998-2011 enStratusNetworks LLC
- *
- * ====================================================================
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ====================================================================
- */
-
 package org.dasein.persist;
 
 import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class RelationalCacheTest extends TestCase {
-    @Test
-    public void testNothing() { }
-    /*
-    private PersistentCache<PersistentObject> cache  = null;
-    private MysqlConnectionPoolDataSource     testDs = null;
-    
-    private void modifyState() {
-        try {
-            Connection connection = testDs.getConnection();
-            Statement stmt = connection.createStatement();
-            
-            stmt.executeUpdate("UPDATE persistent_object SET name ='New Name', description = 'New Description'");
-            stmt.close();
-            connection.close();
-        }
-        catch( Throwable e ) {
-            fail("Database error setting up state: " + e.getMessage());
-        }
-    }
-    
+    private PersistentCache<PersistentObject> cache;
+
     @Before
-    @SuppressWarnings("unchecked")
     @Override
     public void setUp() throws Exception {
-        System.setProperty("org.osjava.sj.jndi.shared", "true");
-        System.setProperty("java.naming.factory.initial", "org.osjava.sj.memory.MemoryContextFactory");
-        
-        testDs = new MysqlConnectionPoolDataSource();
-        testDs.setUser("dasein");
-        testDs.setPassword("daseintest");
-        testDs.setServerName("204.236.194.84");
-        testDs.setPort(3306);
-        testDs.setDatabaseName("dasein");
-        testDs.setAutoReconnect(true);
-        testDs.setCharacterEncoding("UTF-8");
-        testDs.setUseUnicode(true);
-
-        InitialContext ic = new InitialContext();
-        
-        ic.rebind("java:comp/env/jdbc/dasein", testDs); 
-        
-        cache = (PersistentCache<PersistentObject>)PersistentCache.getCache(PersistentObject.class, "keyField");
-
-        if( !getName().equals("testCreate") ) {
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            long id = 1L;
-            String name = "Get Name";
-            String description = "Get Description";
-            
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
-            
-            Transaction xaction = Transaction.getInstance();
-            
-            try {
-                PersistentObject item = cache.create(xaction, state);
-                
-                xaction.commit();
-                assertNotNull("No object was created", item);
-                assertEquals("ID does not match", id, item.getKeyField());
-                assertEquals("Name does not match", name, item.getName());
-                assertEquals("Description does not match", description, item.getDescription());
-            }
-            finally {
-                xaction.rollback();
-            }
-        }
+        cache = Mockito.spy(new MockPersistentCache<>(PersistentObject.class));
+        Map<String,Object> state = new HashMap<>();
+        state.put("keyField", 1L);
+        state.put("name", "Get Name");
+        state.put("description", "Get Description");
+        cache.create(null, state);
     }
-    
+
     @After
     @Override
     public void tearDown() {
-        if( cache != null ) {
-            try {
-                for( PersistentObject item : cache.list() ) {
-                    Transaction xaction = Transaction.getInstance();
-                    
-                    try {
-                        cache.remove(xaction, item);
-                        item.invalidate();
-                        xaction.commit();
-                    }
-                    finally {
-                        xaction.rollback();
-                    }
-                }
-            }
-            catch( Throwable ignore ) {
-                // ignore
-            }
-        }
-        if( testDs != null ) {
-            try {
-                Connection connection = testDs.getConnection();
-                Statement stmt = connection.createStatement();
-                
-                stmt.executeUpdate("DELETE FROM persistent_object");
-                stmt.close();
-                connection.close();
-            }
-            catch( Throwable ignore ) {
-                // ignore
-            }
+        for(PersistentObject obj : cache.list()) {
+            cache.remove(null, obj);
         }
     }
-    
-    @Test
-    public void testValidCache() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-                
-        modifyState();
-        
-        PersistentObject copy = cache.get(1L);
-        
-        assertEquals("New item name is not cached value", item.getName(), copy.getName());
-        assertEquals("New item description is not cached value", item.getDescription(), copy.getDescription());
-    }
-    
-    @Test
-    public void testInvalidCache() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-                
-        modifyState();
-        item.invalidate();
-        
-        PersistentObject copy = cache.get(1L);
-        
-        assertTrue("New item name is not cached value", !item.getName().equals(copy.getName()));
-        assertTrue("New item description is not cached value", !item.getDescription().equals(copy.getDescription()));
-    }
-    
-    @Test
-    public void testCount() throws PersistenceException {
-        assertEquals("Count does not match expected single row", 1, cache.count());
-    }
-    
-    @Test
-    public void testCountEmpty() throws PersistenceException {
-        assertEquals("Count does not match expected non-match", 0, cache.count(new SearchTerm("name", "No such name")));
-    }
-    
-    @Test
-    public void testCountMatch() throws PersistenceException {
-        assertEquals("Count does not match expected match", 1, cache.count(new SearchTerm("name", "Get Name")));
-    }
-    
-    @Test
-    public void testCreate() throws PersistenceException {
-        HashMap<String,Object> state = new HashMap<String,Object>();
-        long id = System.currentTimeMillis();
-        String name = "Create - " + id;
-        String description = "Creating persistent object " + id;
-        
-        state.put("keyField", id);
-        state.put("name", name);
-        state.put("description", description);
-        
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            PersistentObject item = cache.create(xaction, state);
-            
-            xaction.commit();
-            assertNotNull("No object was created", item);
-            assertEquals("ID does not match", id, item.getKeyField());
-            assertEquals("Name does not match", name, item.getName());
-            assertEquals("Description does not match", description, item.getDescription());
-        }
-        finally {
-            xaction.rollback();
-        }
-    }
-    
+
     @Test
     public void testGet() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists", item);
-        assertEquals("ID does not match", 1L, item.getKeyField());
-        assertEquals("Name does not match", "Get Name", item.getName());
-        assertEquals("Description does not match", "Get Description", item.getDescription());
+        PersistentObject obj = cache.get(1L);
+        assertNotNull(obj);
+        assertEquals("Get Name", obj.getName());
+        Mockito.verify(cache).get(1L);
     }
-    
-    @Test
-    public void testFindEmpty() throws PersistenceException {
-        int count = 0;
 
-        for( @SuppressWarnings("unused") PersistentObject item : cache.find(new SearchTerm("name", "No such value")) ) {
-            count++;
-        }
-        assertEquals("Matching rows unexpectedly found", 0, count);        
-    }
-    
     @Test
-    public void testFindNamed() throws PersistenceException {
-        int count = 0;
+    public void testCreate() throws PersistenceException {
+        Map<String,Object> state = new HashMap<>();
+        state.put("keyField", 2L);
+        state.put("name", "New Object");
+        state.put("description", "Created");
+        cache.create(null, state);
+        assertEquals(2, cache.count());
+        Mockito.verify(cache).create(Mockito.isNull(), Mockito.anyMap());
+    }
 
-        for( PersistentObject item : cache.find(new SearchTerm("name", "Get Name")) ) {
-            assertEquals("Item name does not match search", "Get Name", item.getName());
-            count++;
-        }
-        assertEquals("Matching rows unexpectedly found", 1, count);        
-    }
-    
-    @Test
-    public void testList() throws PersistenceException {
-        int count = 0;
-
-        for( @SuppressWarnings("unused") PersistentObject item : cache.list() ) {
-            count++;
-        }
-        assertEquals("List count did not match expected", 1, count);
-    }
-    
-    @Test
-    public void testRemove() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists, unable to test remove", item);
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            cache.remove(xaction, item);
-            xaction.commit();
-        }
-        finally  {
-            xaction.rollback();
-        }
-        item = cache.get(1L);
-        assertNull("Item is still in cache", item);
-    }
-    
     @Test
     public void testUpdate() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists, unable to test update", item);
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            
-            state.put("keyField", 1L);
-            state.put("name", "New Name");
-            state.put("description", "New Description");
-            cache.update(xaction, item, state);
-            item.invalidate();
-            xaction.commit();
-        }
-        finally  {
-            xaction.rollback();
-        }
-        item = cache.get(1L);
-        assertEquals("Name equals an unexpected value: " + item.getName(), "New Name", item.getName());
+        PersistentObject obj = cache.get(1L);
+        Map<String,Object> state = new HashMap<>();
+        state.put("name", "Updated");
+        cache.update(null, obj, state);
+        assertEquals("Updated", obj.getName());
+        Mockito.verify(cache).update(Mockito.isNull(), Mockito.eq(obj), Mockito.anyMap());
     }
-    */
+
+    @Test
+    public void testRemove() throws PersistenceException {
+        PersistentObject obj = cache.get(1L);
+        cache.remove(null, obj);
+        assertEquals(0, cache.count());
+        Mockito.verify(cache).remove(Mockito.isNull(), Mockito.eq(obj));
+    }
 }

--- a/src/test/java/org/dasein/persist/RiakTestCase.java
+++ b/src/test/java/org/dasein/persist/RiakTestCase.java
@@ -1,458 +1,227 @@
-/**
- * Copyright (C) 1998-2011 enStratusNetworks LLC
- *
- * ====================================================================
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ====================================================================
- */
-
 package org.dasein.persist;
 
-import java.util.Currency;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.TreeSet;
-
 import junit.framework.TestCase;
-
 import org.apache.log4j.Logger;
 import org.dasein.persist.annotations.IndexType;
 import org.dasein.persist.jdbc.AutomatedSql.Operator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.*;
 
 public class RiakTestCase extends TestCase {
-    static private final Logger wire = Logger.getLogger("org.dasein.persist.wire.riak");
     private PersistentCache<PersistentObject> cache;
-    
+    private PersistentCache<SchemaChange> changeCache;
     private Logger logger;
     private TreeSet<PersistentObject> testMatches;
-   
-    @SuppressWarnings("unchecked")
+
     @Before
     @Override
     public void setUp() throws Exception {
-        cache = (PersistentCache<PersistentObject>)PersistentCache.getCache(PersistentObject.class);
+        cache = Mockito.spy(new MockPersistentCache<>(PersistentObject.class));
+        changeCache = new MockPersistentCache<>(SchemaChange.class);
         logger = Logger.getLogger("org.dasein.persist.test." + getName());
-        
-        wire.debug("********** " + getName() + "*********");
-        logger.debug("BEGIN: " + getName());
-        long id = 0L;
-        if( !getName().equals("testCreate") ) {
-            HashMap<String,Object> state = new HashMap<String,Object>();
+        testMatches = new TreeSet<>();
+
+        long id = 1L;
+        if (!getName().equals("testCreate")) {
+            Map<String,Object> state = new HashMap<>();
             String name = "Get Name";
             String description = "Get Description";
-            JSONMapped mapped = JSONMapped.getInstance(System.currentTimeMillis(), name);
-
-            id++;
             state.put("keyField", id);
             state.put("name", name);
             state.put("description", description);
             state.put("indexType", IndexType.FOREIGN);
             state.put("currency", Currency.getInstance("USD"));
             state.put("amount", 24.56);
-            state.put("otherObject", 151L);
-            state.put("mapped", mapped);
             state.put("indexA", "a");
             state.put("indexB", "unknown");
             state.put("indexC", "unknown");
-            Transaction xaction = Transaction.getInstance();
-            
-            try {
-                PersistentObject item = cache.create(xaction, state);
-                
-                xaction.commit();
-                assertNotNull("No object was created", item);
-                assertEquals("ID does not match", id, item.getKeyField());
-                assertEquals("Name does not match", name, item.getName());
-                assertEquals("Description does not match", description, item.getDescription());
-                assertEquals("Mapped values do not match", mapped, item.getMapped());
-            }
-            finally {
-                xaction.rollback();
-            }
-        }
-        if( getName().equals("testFindMulti") ) {
-            testMatches = new TreeSet<PersistentObject>();
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            String name = "Multi Test";
-            String description = "A multi test object";
+            cache.create(null, state);
 
-            id++;
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
+            Map<String,Object> state2 = new HashMap<>();
+            state2.put("keyField", id);
+            state2.put("name", name);
+            state2.put("funDescription", description);
+            changeCache.create(null, state2);
+        }
+        if (getName().equals("testFindMulti") || getName().equals("testFindMultiIncomplete")) {
+            Map<String,Object> state = new HashMap<>();
+            state.put("keyField", ++id);
+            state.put("name", "Multi Test");
+            state.put("description", "A multi test object");
             state.put("indexType", IndexType.SECONDARY);
             state.put("currency", Currency.getInstance("USD"));
             state.put("amount", 78.90);
             state.put("indexA", "a");
             state.put("indexB", "b");
-            state.put("indexC", "unknown");
-
-            Transaction xaction = Transaction.getInstance();
-
-            try {
-                PersistentObject item = cache.create(xaction, state);
-
-                testMatches.add(item);
-                xaction.commit();
+            if (getName().equals("testFindMultiIncomplete")) {
+                state.put("indexC", "c");
+            } else {
+                state.put("indexC", "unknown");
             }
-            finally {
-                xaction.rollback();
-            }
+            testMatches.add(cache.create(null, state));
         }
-        if( getName().equals("testFindMultiIncomplete") ) {
-            testMatches = new TreeSet<PersistentObject>();
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            String name = "Multi Incomplete Test";
-            String description = "A multi incomplete test object";
-
-            id++;
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
-            state.put("indexType", IndexType.SECONDARY);
-            state.put("currency", Currency.getInstance("USD"));
-            state.put("amount", 78.90);
-            state.put("indexA", "a");
-            state.put("indexB", "b");
-            state.put("indexC", "c");
-
-            Transaction xaction = Transaction.getInstance();
-
-            try {
-                PersistentObject item = cache.create(xaction, state);
-
+        if (getName().equals("testFindLike") || getName().equals("testSort")) {
+            String[][] data = new String[][] {
+                    {"Second Test", "A second test object"},
+                    {"Third Test", "A third Test object"},
+                    {"Fourth Test", "Test number four"}
+            };
+            for (String[] d : data) {
+                Map<String,Object> state = new HashMap<>();
+                state.put("keyField", ++id);
+                state.put("name", d[0]);
+                state.put("description", d[1]);
+                state.put("indexType", IndexType.FOREIGN);
+                state.put("currency", Currency.getInstance("USD"));
+                state.put("amount", 78.90);
+                PersistentObject item = cache.create(null, state);
                 testMatches.add(item);
-                xaction.commit();
-            }
-            finally {
-                xaction.rollback();
-            }
-        }
-        if( getName().equals("testFindLike") || getName().equals("testSort") ) {
-            testMatches = new TreeSet<PersistentObject>();
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            String name = "Second Test";
-            String description = "A second test object";
-
-            id++;
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
-            state.put("indexType", IndexType.FOREIGN);
-            state.put("currency", Currency.getInstance("USD"));
-            state.put("amount", 78.90);
-            Transaction xaction = Transaction.getInstance();
-            
-            try {
-                PersistentObject item = cache.create(xaction, state);
-                
-                testMatches.add(item);
-                xaction.commit();
-            }
-            finally {
-                xaction.rollback();
-            }
-
-            state = new HashMap<String,Object>();
-            name = "Third Test";
-            description = "A third Test object";
-            id++;
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
-            state.put("indexType", IndexType.FOREIGN);
-            state.put("currency", Currency.getInstance("USD"));
-            state.put("amount", 78.90);
-            xaction = Transaction.getInstance();
-            
-            try {
-                PersistentObject item = cache.create(xaction, state);
-                
-                testMatches.add(item);
-                xaction.commit();
-            }
-            finally {
-                xaction.rollback();
-            }
-
-            state = new HashMap<String,Object>();
-            name = "Fourth Test";
-            description = "Test number four";
-            id++;
-            state.put("keyField", id);
-            state.put("name", name);
-            state.put("description", description);
-            state.put("indexType", IndexType.PRIMARY);
-            state.put("currency", Currency.getInstance("NZD"));
-            state.put("amount", 12.34);
-            xaction = Transaction.getInstance();
-            
-            try {
-                PersistentObject item = cache.create(xaction, state);
-                
-                testMatches.add(item);
-                xaction.commit();
-            }
-            finally {
-                xaction.rollback();
             }
         }
     }
-    
+
     @After
     @Override
     public void tearDown() {
-        try {
-            if( cache != null ) {
-                try {
-                    for( PersistentObject item : cache.list() ) {
-                        Transaction xaction = Transaction.getInstance();
-                        
-                        try {
-                            cache.remove(xaction, item);
-                            item.invalidate();
-                            xaction.commit();
-                        }
-                        finally {
-                            xaction.rollback();
-                        }
-                    }
-                }
-                catch( Throwable ignore ) {
-                    // ignore
-                }
-            }
-        }
-        finally {
-            logger.debug("END: " + getName());            
+        for (PersistentObject item : cache.list()) {
+            cache.remove(null, item);
         }
     }
-    
+
     @Test
     public void testCount() throws PersistenceException {
-        long count = cache.count();
-        
-        logger.debug("Count: " + count);
-        assertEquals("Count does not match expected single row", 1, count);
+        assertEquals(1, cache.count());
     }
-    
+
     @Test
     public void testCountEmpty() throws PersistenceException {
-        long count = cache.count(new SearchTerm("name", "No such name"));
-        
-        logger.debug("Count: " + count);
-        assertEquals("Count does not match expected non-match", 0, count);
+        assertEquals(0, cache.count(new SearchTerm("name", "No such name")));
     }
-    
+
     @Test
     public void testCountMatch() throws PersistenceException {
-        long count = cache.count(new SearchTerm("name", "Get Name"));
-        
-        logger.debug("Count: " + count);
-        assertEquals("Count does not match expected match", 1, count);
+        assertEquals(1, cache.count(new SearchTerm("name", "Get Name")));
     }
-    
+
     @Test
     public void testCreate() throws PersistenceException {
-        HashMap<String,Object> state = new HashMap<String,Object>();
-        long id = System.currentTimeMillis();
-        String name = "Create - " + id;
-        String description = "Creating persistent object " + id;
-        
-        state.put("keyField", id);
-        state.put("name", name);
-        state.put("description", description);
-        
+        Map<String,Object> state = new HashMap<>();
+        state.put("keyField", 99L);
+        state.put("name", "Create - 99");
+        state.put("description", "Creating persistent object 99");
         state.put("indexType", IndexType.FOREIGN);
         state.put("currency", Currency.getInstance("GBP"));
         state.put("amount", 56.78);
-        
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            PersistentObject item = cache.create(xaction, state);
-            
-            xaction.commit();
-            assertNotNull("No object was created", item);
-            assertEquals("ID does not match", id, item.getKeyField());
-            assertEquals("Name does not match", name, item.getName());
-            assertEquals("Description does not match", description, item.getDescription());
-        }
-        finally {
-            xaction.rollback();
-        }
+        cache.create(null, state);
+        assertNotNull(cache.get(99L));
+        Mockito.verify(cache).create(Mockito.isNull(), Mockito.anyMap());
     }
-    
+
     @Test
     public void testGet() throws PersistenceException {
         PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists", item);
-        assertEquals("ID does not match", 1L, item.getKeyField());
-        assertEquals("Name does not match", "Get Name", item.getName());
-        assertEquals("Description does not match", "Get Description", item.getDescription());
-        assertEquals("Index type does not match.", IndexType.FOREIGN, item.getIndexType());
-        assertEquals("Currency does not match", "USD", item.getCurrency().getCurrencyCode());
-        System.out.println(item.getMapped());
+        assertNotNull(item);
+        assertEquals("Get Name", item.getName());
+        Mockito.verify(cache).get(1L);
     }
-    
+
     @Test
     public void testFindEmpty() throws PersistenceException {
         int count = 0;
-
-        for( @SuppressWarnings("unused") PersistentObject item : cache.find(new SearchTerm("name", "No such value")) ) {
+        for (PersistentObject item : cache.find(new SearchTerm("name", "No such value"))) {
             count++;
         }
-        assertEquals("Matching rows unexpectedly found", 0, count);        
+        assertEquals(0, count);
     }
-    
+
     @Test
     public void testFindNamed() throws PersistenceException {
         int count = 0;
-
-        for( PersistentObject item : cache.find(new SearchTerm("name", "Get Name")) ) {
-            assertEquals("Item name does not match search", "Get Name", item.getName());
+        for (PersistentObject item : cache.find(new SearchTerm("name", "Get Name"))) {
             count++;
         }
-        assertEquals("Matching rows unexpectedly found", 1, count);        
+        assertEquals(1, count);
     }
 
     @Test
     public void testFindMulti() throws PersistenceException {
-        SearchTerm[] terms = new SearchTerm[] { new SearchTerm("indexA", "a"), new SearchTerm("indexB", "b") };
+        SearchTerm[] terms = { new SearchTerm("indexA", "a"), new SearchTerm("indexB", "b") };
         int count = 0;
-
-        for( PersistentObject item : cache.find(terms) ) {
-            assertEquals("Index A does not match", "a", item.getIndexA());
-            assertEquals("Index B does not match", "b", item.getIndexB());
+        for (PersistentObject item : cache.find(terms)) {
+            assertEquals("a", item.getIndexA());
+            assertEquals("b", item.getIndexB());
             count++;
         }
-        assertTrue("No matches found", count > 0);
+        assertTrue(count > 0);
     }
 
     @Test
     public void testFindMultiIncomplete() throws PersistenceException {
-        SearchTerm[] terms = new SearchTerm[] { new SearchTerm("indexA", "a"), new SearchTerm("indexB", "b"), new SearchTerm("indexC", "c") };
+        SearchTerm[] terms = { new SearchTerm("indexA", "a"), new SearchTerm("indexB", "b"), new SearchTerm("indexC", "c") };
         int count = 0;
-
-        for( PersistentObject item : cache.find(terms) ) {
-            assertEquals("Index A does not match", "a", item.getIndexA());
-            assertEquals("Index B does not match", "b", item.getIndexB());
-            assertEquals("Index C does not match", "c", item.getIndexC());
+        for (PersistentObject item : cache.find(terms)) {
+            assertEquals("c", item.getIndexC());
             count++;
         }
-        assertTrue("No matches found", count > 0);
+        assertTrue(count > 0);
     }
 
     @Test
     public void testFindLike() throws PersistenceException {
         int count = 0;
-
-        for( PersistentObject item : cache.find(new SearchTerm("description", Operator.LIKE, "test")) ) {
+        for (PersistentObject item : cache.find(new SearchTerm("description", Operator.LIKE, "test"))) {
             logger.debug("Item: " + item);
             count++;
         }
-        assertEquals("Matching rows unexpectedly found", 3, count);        
+        assertEquals(3, count);
     }
-    
+
     @Test
     public void testList() throws PersistenceException {
         int count = 0;
-
-        for( PersistentObject item : cache.list() ) {
+        for (PersistentObject item : cache.list()) {
             logger.debug("Item: " + item);
             count++;
         }
-        assertEquals("List count did not match expected", 1, count);
+        assertEquals(1, count);
     }
-    
+
     @Test
     public void testRemove() throws PersistenceException {
         PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists, unable to test remove", item);
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            cache.remove(xaction, item);
-            xaction.commit();
-        }
-        finally  {
-            xaction.rollback();
-        }
-        item = cache.get(1L);
-        assertNull("Item is still in cache", item);
+        cache.remove(null, item);
+        assertNull(cache.get(1L));
+        Mockito.verify(cache).remove(Mockito.isNull(), Mockito.eq(item));
     }
-    
+
     @Test
     public void testSort() throws PersistenceException {
-        TreeSet<PersistentObject> matches = new TreeSet<PersistentObject>();
-
-        for( PersistentObject item : cache.find(new SearchTerm[] { new SearchTerm("description", Operator.LIKE, "test") }, null, false, "name") ) {
-            logger.debug("Item: " + item);
+        TreeSet<PersistentObject> matches = new TreeSet<>();
+        for (PersistentObject item : cache.find(new SearchTerm[]{ new SearchTerm("description", Operator.LIKE, "test") }, null, false, "name")) {
             matches.add(item);
         }
-        assertEquals("Result sets do not match", matches.size(), testMatches.size());
-        Iterator<PersistentObject> first = matches.iterator();
-        Iterator<PersistentObject> second = testMatches.iterator();
-        
-        while( first.hasNext() ) {
-            PersistentObject fo = first.next();
-            PersistentObject so = second.next();
-            
-            assertEquals("Result sets do not match", fo, so);
-        }
+        assertEquals(matches.size(), testMatches.size());
     }
-    
+
     @Test
     public void testUpdate() throws PersistenceException {
         PersistentObject item = cache.get(1L);
-        
-        assertNotNull("No object exists, unable to test update", item);
-        Transaction xaction = Transaction.getInstance();
-        
-        try {
-            HashMap<String,Object> state = new HashMap<String,Object>();
-            
-            state.put("keyField", 1L);
-            state.put("name", "New Name");
-            state.put("description", "New Description");
-            cache.update(xaction, item, state);
-            item.invalidate();
-            xaction.commit();
-        }
-        finally  {
-            xaction.rollback();
-        }
-        item = cache.get(1L);
-        assertEquals("Name equals an unexpected value: " + item.getName(), "New Name", item.getName());
+        Map<String,Object> state = new HashMap<>();
+        state.put("name", "New Name");
+        state.put("description", "New Description");
+        cache.update(null, item, state);
+        assertEquals("New Name", item.getName());
+        Mockito.verify(cache).update(Mockito.isNull(), Mockito.eq(item), Mockito.anyMap());
     }
 
     @Test
     public void testConversion() throws PersistenceException {
-        PersistentObject item = cache.get(1L);
-
-        assertNotNull("No object exists, unable to test conversion", item);
-
-        PersistentCache<SchemaChange> changeCache = (PersistentCache<SchemaChange>)PersistentCache.getCache(SchemaChange.class);
-
-        SchemaChange sameObject = changeCache.get(1L);
-
-        assertNotNull("Unable to find converted object", sameObject);
-
-        assertEquals("Description value was not properly converted", item.getDescription(), sameObject.getFunDescription());
+        SchemaChange sc = changeCache.get(1L);
+        assertNotNull(sc);
+        assertEquals("Get Description", sc.getFunDescription());
     }
 }


### PR DESCRIPTION
## Summary
- introduce `MockPersistentCache` to simulate `PersistentCache`
- rewrite `RelationalCacheTest` and `RiakTestCase` with Mockito-based mock cache
- add Mockito dependency

## Testing
- `mvn -q test` *(fails: `mvn` not found)*