### PR TITLE
Fix tests compilation by throwing PersistenceException

### DIFF
--- a/src/test/java/org/dasein/persist/RelationalCacheTest.java
+++ b/src/test/java/org/dasein/persist/RelationalCacheTest.java
@@ -25,7 +25,7 @@ public class RelationalCacheTest extends TestCase {
 
     @After
     @Override
-    public void tearDown() {
+    public void tearDown() throws PersistenceException {
         for(PersistentObject obj : cache.list()) {
             cache.remove(null, obj);
         }

--- a/src/test/java/org/dasein/persist/RiakTestCase.java
+++ b/src/test/java/org/dasein/persist/RiakTestCase.java
@@ -86,7 +86,7 @@ public class RiakTestCase extends TestCase {
 
     @After
     @Override
-    public void tearDown() {
+    public void tearDown() throws PersistenceException {
         for (PersistentObject item : cache.list()) {
             cache.remove(null, item);
         }


### PR DESCRIPTION
## Summary
- update RelationalCacheTest and RiakTestCase tearDown methods to declare `PersistenceException`

## Testing
- `mvn` not installed in this environment, so tests were not run