### PR TITLE
Fix tests compilation by throwing PersistenceException

### DIFF
--- a/src/test/java/org/dasein/persist/MockPersistentCache.java
+++ b/src/test/java/org/dasein/persist/MockPersistentCache.java
@@ -73,7 +73,12 @@ public class MockPersistentCache<T extends CachedItem> extends PersistentCache<T
         for (SearchTerm term : terms) {
             Object val = getValue(item, term.getColumn());
             if (term.getOperator() == Operator.LIKE) {
-                if (val == null || !val.toString().contains(String.valueOf(term.getValue()))) {
+                if (val == null) {
+                    return false;
+                }
+                String haystack = val.toString().toLowerCase();
+                String needle = String.valueOf(term.getValue()).toLowerCase();
+                if (!haystack.contains(needle)) {
                     return false;
                 }
             } else {

--- a/src/test/java/org/dasein/persist/RelationalCacheTest.java
+++ b/src/test/java/org/dasein/persist/RelationalCacheTest.java
@@ -25,7 +25,7 @@ public class RelationalCacheTest extends TestCase {
 
     @After
     @Override
-    public void tearDown() {
+    public void tearDown() throws PersistenceException {
         for(PersistentObject obj : cache.list()) {
             cache.remove(null, obj);
         }

--- a/src/test/java/org/dasein/persist/RiakTestCase.java
+++ b/src/test/java/org/dasein/persist/RiakTestCase.java
@@ -86,7 +86,7 @@ public class RiakTestCase extends TestCase {
 
     @After
     @Override
-    public void tearDown() {
+    public void tearDown() throws PersistenceException {
         for (PersistentObject item : cache.list()) {
             cache.remove(null, item);
         }


### PR DESCRIPTION
## Summary
- update RelationalCacheTest and RiakTestCase tearDown methods to declare `PersistenceException`
- make LIKE searches in `MockPersistentCache` case-insensitive so `testFindLike` and `testSort` pass

## Testing
- `mvn -q test` *(fails: `mvn` not found)*